### PR TITLE
Migrate to latest container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <groupId>org.sonatype.sisu</groupId>
   <artifactId>sisu-bundle-launcher-aggregator</artifactId>
   <packaging>pom</packaging>
-  <version>1.5.4-SNAPSHOT</version>
+  <version>1.6-SNAPSHOT</version>
 
   <inceptionYear>2008</inceptionYear>
   <url>https://github.com/sonatype/sisu-bundle-launcher</url>
@@ -67,14 +67,19 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>org.eclipse.sisu.inject</artifactId>
+        <version>0.1.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.sonatype.sisu</groupId>
-        <artifactId>sisu-inject-bean</artifactId>
-        <version>2.3.2</version>
+        <artifactId>sisu-guice</artifactId>
+        <version>3.1.8</version>
       </dependency>
       <dependency>
         <groupId>org.sonatype.sisu</groupId>
         <artifactId>sisu-maven-bridge</artifactId>
-        <version>3.0</version>
+        <version>3.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -95,7 +100,7 @@
       <dependency>
         <groupId>org.sonatype.sisu.goodies</groupId>
         <artifactId>goodies-common</artifactId>
-        <version>1.5.1</version>
+        <version>1.8-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ant</groupId>
@@ -111,7 +116,7 @@
       <dependency>
         <groupId>org.sonatype.sisu.litmus</groupId>
         <artifactId>litmus-testsupport</artifactId>
-        <version>1.6</version>
+        <version>1.8-SNAPSHOT</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -131,17 +136,17 @@
       <dependency>
         <groupId>org.sonatype.sisu</groupId>
         <artifactId>sisu-bundle-launcher</artifactId>
-        <version>1.5.4-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.sonatype.sisu</groupId>
         <artifactId>sisu-bundle-launcher-servlet</artifactId>
-        <version>1.5.4-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.sonatype.sisu</groupId>
         <artifactId>sisu-file-tasks</artifactId>
-        <version>1.5.4-SNAPSHOT</version>
+        <version>1.6-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -197,8 +202,10 @@
                 <bannedDependencies>
                   <searchTransitive>true</searchTransitive>
                   <excludes>
-                    <!-- Keep junit out, use junit-dep instead -->
-                    <exclude>junit:junit</exclude>
+                    <!-- Keep old junits out -->
+                    <exclude>junit:junit:(,4.10]</exclude>
+                    <exclude>junit:junit-dep</exclude>
+
                     <!-- Keep all JCL out, use jcl-over-slf4j instead -->
                     <exclude>commons-logging:commons-logging</exclude>
                     <exclude>commons-logging:commons-logging-api</exclude>

--- a/sisu-bundle-launcher-jetty-testsuite/pom.xml
+++ b/sisu-bundle-launcher-jetty-testsuite/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu</groupId>
     <artifactId>sisu-bundle-launcher-aggregator</artifactId>
-    <version>1.5.4-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>sisu-bundle-launcher-jetty-testsuite</artifactId>
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
       <artifactId>sisu-bundle-launcher-jetty</artifactId>
-      <version>1.5.4-SNAPSHOT</version>
+      <version>1.6-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/sisu-bundle-launcher-jetty/pom.xml
+++ b/sisu-bundle-launcher-jetty/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu</groupId>
     <artifactId>sisu-bundle-launcher-aggregator</artifactId>
-    <version>1.5.4-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>sisu-bundle-launcher-jetty</artifactId>

--- a/sisu-bundle-launcher-jetty/src/main/java/org/sonatype/sisu/bl/servlet/jetty/internal/DefaultJettyBundleConfiguration.java
+++ b/sisu-bundle-launcher-jetty/src/main/java/org/sonatype/sisu/bl/servlet/jetty/internal/DefaultJettyBundleConfiguration.java
@@ -16,9 +16,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
-import org.sonatype.inject.Nullable;
 import org.sonatype.sisu.bl.jmx.JMXConfiguration;
-import org.sonatype.sisu.bl.servlet.internal.DefaultServletContainerBundleConfiguration;
 import org.sonatype.sisu.bl.servlet.jetty.JettyBundleConfiguration;
 
 /**

--- a/sisu-bundle-launcher-jetty/src/main/java/org/sonatype/sisu/bl/servlet/jetty/internal/JettyBasedBundleConfigurationSupport.java
+++ b/sisu-bundle-launcher-jetty/src/main/java/org/sonatype/sisu/bl/servlet/jetty/internal/JettyBasedBundleConfigurationSupport.java
@@ -12,15 +12,14 @@
  */
 package org.sonatype.sisu.bl.servlet.jetty.internal;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
-import org.sonatype.inject.Nullable;
 import org.sonatype.sisu.bl.jmx.JMXConfiguration;
 import org.sonatype.sisu.bl.servlet.internal.DefaultServletContainerBundleConfiguration;
 import org.sonatype.sisu.bl.servlet.jetty.JettyBasedBundleConfiguration;
-import org.sonatype.sisu.bl.servlet.jetty.JettyBundleConfiguration;
 
 /**
  * {@link JettyBasedBundleConfiguration} implementation support.

--- a/sisu-bundle-launcher-jetty/src/main/java/org/sonatype/sisu/bl/servlet/jetty/internal/JettyBundleResolver.java
+++ b/sisu-bundle-launcher-jetty/src/main/java/org/sonatype/sisu/bl/servlet/jetty/internal/JettyBundleResolver.java
@@ -12,10 +12,10 @@
  */
 package org.sonatype.sisu.bl.servlet.jetty.internal;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.sonatype.inject.Nullable;
 import org.sonatype.sisu.bl.support.resolver.MavenBridgedBundleResolver;
 import org.sonatype.sisu.maven.bridge.MavenArtifactResolver;
 

--- a/sisu-bundle-launcher-servlet/pom.xml
+++ b/sisu-bundle-launcher-servlet/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu</groupId>
     <artifactId>sisu-bundle-launcher-aggregator</artifactId>
-    <version>1.5.4-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>sisu-bundle-launcher-servlet</artifactId>

--- a/sisu-bundle-launcher-tomcat/pom.xml
+++ b/sisu-bundle-launcher-tomcat/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.sisu</groupId>
     <artifactId>sisu-bundle-launcher-aggregator</artifactId>
-    <version>1.5.4-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>sisu-bundle-launcher-tomcat</artifactId>

--- a/sisu-bundle-launcher-tomcat/src/main/java/org/sonatype/sisu/bl/servlet/tomcat/internal/DefaultTomcatBundleConfiguration.java
+++ b/sisu-bundle-launcher-tomcat/src/main/java/org/sonatype/sisu/bl/servlet/tomcat/internal/DefaultTomcatBundleConfiguration.java
@@ -12,15 +12,14 @@
  */
 package org.sonatype.sisu.bl.servlet.tomcat.internal;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
-import org.sonatype.inject.Nullable;
 import org.sonatype.sisu.bl.jmx.JMXConfiguration;
 import org.sonatype.sisu.bl.servlet.internal.DefaultServletContainerBundleConfiguration;
 import org.sonatype.sisu.bl.servlet.tomcat.TomcatBundleConfiguration;
-import org.sonatype.sisu.bl.support.resolver.BundleResolver;
 
 /**
  * TODO

--- a/sisu-bundle-launcher-tomcat/src/main/java/org/sonatype/sisu/bl/servlet/tomcat/internal/TomcatBundleResolver.java
+++ b/sisu-bundle-launcher-tomcat/src/main/java/org/sonatype/sisu/bl/servlet/tomcat/internal/TomcatBundleResolver.java
@@ -12,10 +12,10 @@
  */
 package org.sonatype.sisu.bl.servlet.tomcat.internal;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.sonatype.inject.Nullable;
 import org.sonatype.sisu.bl.support.resolver.MavenBridgedBundleResolver;
 import org.sonatype.sisu.maven.bridge.MavenArtifactResolver;
 

--- a/sisu-bundle-launcher/pom.xml
+++ b/sisu-bundle-launcher/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.sisu</groupId>
     <artifactId>sisu-bundle-launcher-aggregator</artifactId>
-    <version>1.5.4-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>sisu-bundle-launcher</artifactId>
@@ -30,8 +30,12 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-bean</artifactId>
+      <artifactId>sisu-guice</artifactId>
     </dependency>
     <dependency>
       <groupId>org.sonatype.sisu</groupId>

--- a/sisu-bundle-launcher/src/main/java/org/sonatype/sisu/bl/support/DefaultBundleConfiguration.java
+++ b/sisu-bundle-launcher/src/main/java/org/sonatype/sisu/bl/support/DefaultBundleConfiguration.java
@@ -19,11 +19,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
-import org.sonatype.inject.Nullable;
 import org.sonatype.sisu.bl.BundleConfiguration;
 import org.sonatype.sisu.bl.jmx.JMXConfiguration;
 import org.sonatype.sisu.bl.support.resolver.BundleResolver;

--- a/sisu-bundle-launcher/src/main/java/org/sonatype/sisu/bl/support/resolver/MavenBridgedBundleResolver.java
+++ b/sisu-bundle-launcher/src/main/java/org/sonatype/sisu/bl/support/resolver/MavenBridgedBundleResolver.java
@@ -15,12 +15,12 @@ package org.sonatype.sisu.bl.support.resolver;
 
 import java.io.File;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.sonatype.aether.artifact.Artifact;
 import org.sonatype.aether.resolution.ArtifactResolutionException;
-import org.sonatype.inject.Nullable;
 import org.sonatype.sisu.maven.bridge.MavenArtifactResolver;
 
 import com.google.common.base.Throwables;

--- a/sisu-file-tasks/pom.xml
+++ b/sisu-file-tasks/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.sisu</groupId>
     <artifactId>sisu-bundle-launcher-aggregator</artifactId>
-    <version>1.5.4-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>sisu-file-tasks</artifactId>
@@ -31,13 +31,18 @@
     </dependency>
     <dependency>
       <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-inject-bean</artifactId>
+      <artifactId>sisu-guice</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.sonatype.sisu.litmus</groupId>
       <artifactId>litmus-testsupport</artifactId>


### PR DESCRIPTION
Guice is now a provided dependency of Sisu, making it easier to swap between editions without needing exclusions.
