### PR TITLE
turning off extra checks in javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,17 @@
             <workingDirectory>${project.build.directory}</workingDirectory>
           </configuration>
         </plugin>
+
+        <!-- 
+          Turn off strict javadoc checks in Java8. 
+        -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <additionalparam>-Xdoclint:none</additionalparam>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
when trying to release, the build fails when it runs `javadoc:jar`

the failures are related to extra checks that exist now, this change disables the extra checking...